### PR TITLE
A variety of thread and memory fixes

### DIFF
--- a/src/SurgeFXEditor.cpp
+++ b/src/SurgeFXEditor.cpp
@@ -101,11 +101,13 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor (SurgefxAudioProcessor&
     }
     
 
-    this->processor.setParameterChangeListener([this]() { this->paramsChangedCallback(); });
+    this->processor.setParameterChangeListener([this]() { this->triggerAsyncUpdate(); } );
 }
 
 SurgefxAudioProcessorEditor::~SurgefxAudioProcessorEditor()
 {
+    setLookAndFeel(nullptr);
+    this->processor.setParameterChangeListener([](){});
 }
 
 void SurgefxAudioProcessorEditor::resetLabels()
@@ -128,6 +130,10 @@ void SurgefxAudioProcessorEditor::setEffectType(int i)
     processor.resetFxType(i);
     blastToggleState(i-1);
     resetLabels();
+}
+
+void SurgefxAudioProcessorEditor::handleAsyncUpdate() {
+    paramsChangedCallback();
 }
 
 void SurgefxAudioProcessorEditor::paramsChangedCallback() {

--- a/src/SurgeFXEditor.h
+++ b/src/SurgeFXEditor.h
@@ -17,7 +17,7 @@
 //==============================================================================
 /**
 */
-class SurgefxAudioProcessorEditor  : public AudioProcessorEditor
+class SurgefxAudioProcessorEditor  : public AudioProcessorEditor, AsyncUpdater
 {
 public:
     SurgefxAudioProcessorEditor (SurgefxAudioProcessor&);
@@ -30,6 +30,8 @@ public:
     void paramsChangedCallback();
     void setEffectType(int i);
 
+    virtual void handleAsyncUpdate() override;
+    
     enum RadioGroupIds {
         FxTypeGroup = 1776
     };

--- a/src/SurgeFXProcessor.h
+++ b/src/SurgeFXProcessor.h
@@ -236,7 +236,10 @@ private:
     
     // Members for the FX. If this looks a lot like surge-rack/SurgeFX.hpp that's not a coincidence
     std::unique_ptr<SurgeStorage> storage;
-    std::unique_ptr<Effect> surge_effect;
+    
+    std::shared_ptr<Effect> surge_effect;
+    std::shared_ptr<Effect> audio_thread_surge_effect;
+    std::atomic<bool> resettingFx;
     FxStorage *fxstorage;
     int storage_id_start, storage_id_end;
 


### PR DESCRIPTION
A variety of memory and thread fixes which were causing crashes
and problems.

1. We change the FX type with a spawn on the UI thread but use it
   on the audio thread. So we could sometimes delete ourselves
   beneath our running audio. Crashed windows. Fix by having a
   pair of shared_ptrs and a resetting atomic helper

2. We would udpate parameters synchronously independent of whether
   an editor existed. This caused crashes automating parameters
   and when closing displays. Fix by resetting the parameter callback
   in the editor and calling it asynchronously.

3. We unbind to the look and feel to avoid a JUCE debug assert and leak