### PR TITLE
Add the JUCE compatibility patch for GCC 9

### DIFF
--- a/Makefile.lin
+++ b/Makefile.lin
@@ -11,7 +11,9 @@ assets:
 
 assets/juce-5.4.3-linux.zip:
 	curl -o assets/juce-5.4.3-linux.zip https://d30pueezughrda.cloudfront.net/juce/juce-5.4.3-linux.zip
+	curl -o assets/juce-5.4.3-gcc9.patch https://github.com/WeAreROLI/JUCE/commit/4e0adb2af8b424c43d22bd431011c9a6c57d36b6.patch
 	cd assets && unzip juce-5.4.3-linux.zip
+	patch -N -p1 -d assets/JUCE -i ../juce-5.4.3-gcc9.patch
 
 assets/JUCE: assets assets/juce-5.4.3-linux.zip
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,6 +122,7 @@ jobs:
       sudo apt-get install -y jack
       sudo apt-get install -y libjack-dev
       sudo apt-get install -y libfreetype6-dev
+      sudo apt-get install -y libgl1-mesa-dev
 
       # OK so what the heck is going on
       echo "===PKG CONFIGS==="


### PR DESCRIPTION
Hi, this JUCE version does not build on GCC 9, it needs to import a patch in order to fix it.
It's only recent versions of GCC, it does not affect either Clang or the older versions.