### PR TITLE
Move the surge pointer

### DIFF
--- a/surge-fx.jucer
+++ b/surge-fx.jucer
@@ -13,6 +13,10 @@
               file="resources/SurgeLogoOnlyBlue.svg"/>
       </GROUP>
       <GROUP id="{AF603B09-893E-1A7F-FA6F-D1E37E4F550C}" name="libs">
+        <GROUP id="{6F816D5D-F204-C46E-B2B1-76EA4AC318A7}" name="srtnatcmp">
+          <FILE id="CNDPCm" name="strnatcmp.cpp" compile="1" resource="0" file="deps/surge/libs/strnatcmp/strnatcmp.cpp"/>
+          <FILE id="hb3vLx" name="strnatcmp.h" compile="0" resource="0" file="deps/surge/libs/strnatcmp/strnatcmp.h"/>
+        </GROUP>
         <GROUP id="{2A752819-DDB0-3927-929D-EBC295D0E9F0}" name="filesystem">
           <FILE id="KOZCaG" name="filesystem.cpp" compile="1" resource="0" file="deps/surge/libs/filesystem/filesystem.cpp"/>
           <FILE id="vMV90B" name="filesystem.h" compile="0" resource="0" file="deps/surge/libs/filesystem/filesystem.h"/>
@@ -219,7 +223,7 @@
   </MAINGROUP>
   <EXPORTFORMATS>
     <XCODE_MAC targetFolder="Builds/MacOSX" vst3Folder="deps/surge/vst3sdk"
-               extraCompilerFlags="-DJUCE_DISPLAY_SPLASH_SCREEN=0 -DJUCE_REPORT_APP_USAGE=0 -DMAC=1 -DTARGET_HEADLESS=1 -I../../deps/surge/src/common -I../../deps/surge/src/common/dsp -I../../deps/surge/src/common/dsp/effects -I../../deps/surge/libs/xml -I../../deps/surge/libs/filesystem -I../../deps/surge/src/headless -Wno-c++17-extensions -D_aligned_malloc(x,a)=malloc(x) -D_aligned_free(x)=free(x)">
+               extraCompilerFlags="-DJUCE_DISPLAY_SPLASH_SCREEN=0 -DJUCE_REPORT_APP_USAGE=0 -DMAC=1 -DTARGET_HEADLESS=1 -I../../deps/surge/src/common -I../../deps/surge/src/common/dsp -I../../deps/surge/src/common/dsp/effects -I../../deps/surge/libs/xml -I../../deps/surge/libs/strnatcmp -I../../deps/surge/libs/filesystem -I../../deps/surge/src/headless -Wno-c++17-extensions -D_aligned_malloc(x,a)=malloc(x) -D_aligned_free(x)=free(x)">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug"/>
         <CONFIGURATION isDebug="0" name="Release"/>
@@ -241,7 +245,7 @@
         <MODULEPATH id="juce_opengl" path="./assets/JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
-    <VS2017 targetFolder="Builds/VisualStudio2017" extraCompilerFlags="/FI precompiled.h /DNOMINMAX=1 /DJUCE_DISPLAY_SPLASH_SCREEN=0 /DTIXML_USE_STL /DWIN32 /DJUCE_REPORT_APP_USAGE=0 /DWINDOWS=1 /DTARGET_HEADLESS=1 /Mp /Zc:alignedNew /std:c++17 /bigobj /I../../deps/surge/src/common -I../../deps/surge/src/common/dsp -I../../deps/surge/src/common/dsp/effects -I../../deps/surge/libs/xml -I../../deps/surge/src/headless"
+    <VS2017 targetFolder="Builds/VisualStudio2017" extraCompilerFlags="/FI precompiled.h /DNOMINMAX=1 /DJUCE_DISPLAY_SPLASH_SCREEN=0 /DTIXML_USE_STL /DWIN32 /DJUCE_REPORT_APP_USAGE=0 /DWINDOWS=1 /DTARGET_HEADLESS=1 /Mp /Zc:alignedNew /std:c++17 /bigobj /I../../deps/surge/src/common -I../../deps/surge/src/common/dsp -I../../deps/surge/src/common/dsp/effects -I../../deps/surge/libs/xml -I../../deps/surge/libs/strnatcmp -I../../deps/surge/src/headless"
             extraLinkerFlags="">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug"/>
@@ -266,7 +270,7 @@
       </MODULEPATHS>
     </VS2017>
     <LINUX_MAKE targetFolder="Builds/LinuxMakefile" vst3Folder="deps/surge/vst3sdk"
-                extraLinkerFlags="-lstdc++fs -pthread" extraCompilerFlags="-fPIC -DJUCE_DISPLAY_SPLASH_SCREEN=0 -DJUCE_REPORT_APP_USAGE=0 -DLINUX=1 -DTARGET_HEADLESS=1 -I../../deps/surge/src/linux -I../../deps/surge/src/common -I../../deps/surge/src/common/dsp -I../../deps/surge/src/common/dsp/effects -I../../deps/surge/libs/xml -I../../deps/surge/libs/filesystem&#10;-I../../deps/surge/src/headless -I../../src -include LinuxAligned.h"
+                extraLinkerFlags="-lstdc++fs -pthread" extraCompilerFlags="-fPIC -DJUCE_DISPLAY_SPLASH_SCREEN=0 -DJUCE_REPORT_APP_USAGE=0 -DLINUX=1 -DTARGET_HEADLESS=1 -I../../deps/surge/src/linux -I../../deps/surge/src/common -I../../deps/surge/src/common/dsp -I../../deps/surge/src/common/dsp/effects -I../../deps/surge/libs/xml -I../../deps/surge/libs/strnatcmp -I../../deps/surge/libs/filesystem&#10;-I../../deps/surge/src/headless -I../../src -include LinuxAligned.h"
                 vstLegacyFolder="VST2SDK_DIR">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="0" name="Debug"/>


### PR DESCRIPTION
Move the surge pointer to current head; pick up the new distortion changes
as a result. Probably move again when I do 1.6.3